### PR TITLE
Improve fetch id logic

### DIFF
--- a/init.rb
+++ b/init.rb
@@ -59,7 +59,7 @@ class Heroku::Command::Cake < Heroku::Command::Base
   end
 
   def backup_id
-    id = `heroku pg:backups --app #{app} | grep #{remote_database}| cut -d " " -f1`.split("\n").first
+    id = `heroku pg:backups --app #{app} 2> /dev/null | grep #{remote_database}| cut -d " " -f1`.split("\n").first
   end
 
   def remote_database

--- a/init.rb
+++ b/init.rb
@@ -59,7 +59,7 @@ class Heroku::Command::Cake < Heroku::Command::Base
   end
 
   def backup_id
-    id = `heroku pg:backups --app #{app} 2> /dev/null | grep #{remote_database}| cut -d " " -f1`.split("\n").first
+    `heroku pg:backups --app #{app} 2> /dev/null | ag -i "^(?=.*\bfinished\b)(?=.*\b#{remote_database}\b).*$" | head -1 | cut -d " " -f 1`.chomp
   end
 
   def remote_database

--- a/init.rb
+++ b/init.rb
@@ -59,7 +59,7 @@ class Heroku::Command::Cake < Heroku::Command::Base
   end
 
   def backup_id
-    `heroku pg:backups --app #{app} 2> /dev/null | ag -i "^(?=.*\bfinished\b)(?=.*\b#{remote_database}\b).*$" | head -1 | cut -d " " -f 1`.chomp
+    `heroku pg:backups --app #{app} 2> /dev/null | awk '{ if($5 == "Finished" && $NF == "#{remote_database}") print $1 }' | head -1`.chomp
   end
 
   def remote_database


### PR DESCRIPTION
This change makes sure that only successful backup ids are fetched, it also stops the following error message from appearing

```bash
 !    No restores found. Use `heroku pg:backups restore` to restore a backup
```