### PR TITLE
Only drop and recreate the development database.

### DIFF
--- a/init.rb
+++ b/init.rb
@@ -42,7 +42,7 @@ class Heroku::Command::Cake < Heroku::Command::Base
   end
 
   def drop_then_create
-    `bundle exec rake db:drop && bundle exec rake db:create`
+    `RAILS_ENV=development bundle exec rake db:drop && bundle exec rake db:create`
   end
 
   def restore


### PR DESCRIPTION
Rails `database_tasks` automatically adds the test environment to any rake task that doesn't set a value to `RAILS_ENV`

Here's the culprit [piece of code](https://github.com/rails/rails/blob/master/activerecord/lib/active_record/tasks/database_tasks.rb#L265-L274).

cc @davegriffiths @daemonsy @jjbohn 